### PR TITLE
Task/3.1 register GitHub oauth app

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,2 +1,0 @@
-ignore_paths:
-  - backend/manual_migrations/

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,6 +32,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run tests
         working-directory: backend
-        run: cargo test --all-features
+        run: cargo test --all-features -- --include-ignored
 
       - name: Build
         working-directory: backend

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ Cargo.lock
 
 # Environment files
 .env
+backend/.env
+frontend/.env
 
 # General
 *.log

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Ignore secrets in backend/.env
+backend/.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,7 +14,8 @@ PORT=8081
 # GitHub OAuth Configuration
 GITHUB_CLIENT_ID=your_github_client_id_here
 GITHUB_CLIENT_SECRET=your_github_client_secret_here
-GITHUB_CALLBACK_URL=http://localhost:3001/auth/callback
+# This must match the callback URL registered in your GitHub OAuth app settings exactly (including port and path)
+GITHUB_REDIRECT_URL=http://localhost:3001/auth/callback
 GITHUB_OAUTH_SCOPES=read:org,read:user,repo
 
 # JWT Configuration

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "personal-github-dashboard"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "personal-github-dashboard"
@@ -98,3 +98,4 @@ opt-level = 1
 
 [dev-dependencies]
 actix-service = "2"
+serial_test = "0.6.0"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -77,5 +77,11 @@ metrics-exporter-prometheus = "0.11"
 # Testing
 actix-rt = "2"
 
+# Encryption/Decryption
+ring = "0.17"
+
+# Lazy initialization
+once_cell = "1.18.0"
+
 [dev-dependencies]
 actix-service = "2"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -83,5 +83,18 @@ ring = "0.17"
 # Lazy initialization
 once_cell = "1.18.0"
 
+# Optional: Remove unused or heavy dependencies (manual audit required)
+# Example: Remove octocrab if not used, or replace with lighter alternative
+# [dependencies]
+# octocrab = "0.44.0"  # Remove if not used
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "z"
+
+[profile.dev]
+opt-level = 1
+
 [dev-dependencies]
 actix-service = "2"

--- a/backend/migrations/20250429110000_create_oauth_tokens_table.sql
+++ b/backend/migrations/20250429110000_create_oauth_tokens_table.sql
@@ -1,4 +1,6 @@
 -- Migration: Create oauth_tokens table for storing encrypted OAuth tokens
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE TABLE oauth_tokens (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/migrations/20250429110000_create_oauth_tokens_table.sql
+++ b/backend/migrations/20250429110000_create_oauth_tokens_table.sql
@@ -1,0 +1,16 @@
+-- Migration: Create oauth_tokens table for storing encrypted OAuth tokens
+CREATE TABLE oauth_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider VARCHAR(32) NOT NULL DEFAULT 'github',
+    access_token BYTEA NOT NULL, -- encrypted
+    refresh_token BYTEA,         -- encrypted
+    token_type VARCHAR(32),
+    scope VARCHAR(255),
+    expiry TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+CREATE INDEX idx_oauth_tokens_user_id ON oauth_tokens(user_id);
+CREATE INDEX idx_oauth_tokens_provider ON oauth_tokens(provider);

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -3,27 +3,29 @@ use crate::models::organization::Organization;
 use crate::models::repository::Repository;
 use crate::models::user::User;
 use crate::utils::cache::{
-    activity_cache_key, org_cache_key, repo_cache_key, ttl_user, user_cache_key, TTL_ACTIVITY,
-    TTL_REPO,
+    TTL_ACTIVITY, TTL_REPO, activity_cache_key, org_cache_key, repo_cache_key, ttl_user,
+    user_cache_key,
 };
 use crate::utils::redis::RedisClient;
 use chrono::{DateTime, Utc};
-use log::{debug, info, warn};
+use log::{debug, warn};
 use metrics::{histogram, increment_counter};
 use serde_json::Value;
 use sqlx::Error;
-use sqlx::{postgres::PgPoolOptions, PgPool};
+use sqlx::{PgPool, postgres::PgPoolOptions};
 use std::time::Duration;
 use uuid::Uuid;
 
 /// Creates a PostgreSQL connection pool with a maximum number of connections and a 5-second acquire timeout.
+
 ///
 /// # Examples
 ///
 /// ```
 /// let pool = create_pg_pool("postgres://user:pass@localhost/db", 10).await;
 /// assert!(pool.is_closed() == false);
-/// ```pub async fn create_pg_pool(database_url: &str, max_connections: u32) -> PgPool {
+/// ```
+pub async fn create_pg_pool(database_url: &str, max_connections: u32) -> PgPool {
     PgPoolOptions::new()
         .max_connections(max_connections)
         .acquire_timeout(Duration::from_secs(5))
@@ -43,7 +45,8 @@ use uuid::Uuid;
 /// ```
 /// let pool = create_pg_pool_memory_efficient("postgres://user:pass@localhost/db", 10).await;
 /// assert!(pool.acquire().await.is_ok());
-/// ```pub async fn create_pg_pool_memory_efficient(database_url: &str, max_connections: u32) -> PgPool {
+/// ```
+pub async fn create_pg_pool_memory_efficient(database_url: &str, max_connections: u32) -> PgPool {
     PgPoolOptions::new()
         .max_connections(max_connections)
         .min_connections(1) // keep only 1 idle connection

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -17,10 +17,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 /// Creates a PostgreSQL connection pool with a maximum number of connections and a 5-second acquire timeout.
-
-///
 /// # Examples
-///
 /// ```
 /// let pool = create_pg_pool("postgres://user:pass@localhost/db", 10).await;
 /// assert!(pool.is_closed() == false);
@@ -35,13 +32,10 @@ pub async fn create_pg_pool(database_url: &str, max_connections: u32) -> PgPool 
 }
 
 /// Creates a PostgreSQL connection pool optimized for memory efficiency.
-///
 /// The pool maintains a minimum of one idle connection, limits the maximum number of connections,
 /// sets a maximum connection lifetime of 10 minutes, and applies a 60-second idle timeout. Each new
 /// connection is configured with a 5-second statement timeout.
-///
 /// # Examples
-///
 /// ```
 /// let pool = create_pg_pool_memory_efficient("postgres://user:pass@localhost/db", 10).await;
 /// assert!(pool.acquire().await.is_ok());
@@ -67,11 +61,8 @@ pub async fn create_pg_pool_memory_efficient(database_url: &str, max_connections
 }
 
 /// Retrieves a user by their unique identifier from the database.
-///
 /// Returns `Ok(Some(User))` if a user with the given ID exists, `Ok(None)` if not found, or an error if the query fails.
-///
 /// # Examples
-///
 /// ```
 /// let user = get_user_by_id(&pool, &user_id).await?;
 /// if let Some(user) = user {

--- a/backend/src/handlers/activities.rs
+++ b/backend/src/handlers/activities.rs
@@ -2,7 +2,7 @@ use crate::db::{
     create_activity_with_cache, delete_activity_with_cache, get_activity_by_id_with_cache,
 };
 use crate::utils::redis::RedisClient;
-use actix_web::{web, HttpResponse};
+use actix_web::{HttpResponse, web};
 use serde::Deserialize;
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -28,6 +28,16 @@ pub struct OAuthRequest {
     pub state: String,
 }
 
+/// Redirects the client to the GitHub OAuth authorization page.
+///
+/// Constructs a GitHub OAuth authorization URL with the required client ID, redirect URI, state, and scopes, then returns an HTTP 302 redirect to initiate the OAuth login flow.
+///
+/// # Examples
+///
+/// ```
+/// let response = login();
+/// assert_eq!(response.status(), actix_web::http::StatusCode::FOUND);
+/// ```
 pub async fn login() -> HttpResponse {
     // Load OAuth config and generate state
     let cfg = Config::from_env();
@@ -44,6 +54,20 @@ pub async fn login() -> HttpResponse {
         .finish()
 }
 
+/// Handles the OAuth callback from GitHub, exchanges the authorization code for an access token, retrieves user information, persists user and token data, and establishes a session with a JWT.
+///
+/// In test mode (`TEST_MODE=1`), bypasses real OAuth and issues a test JWT for a dummy user.
+///
+/// # Examples
+///
+/// ```
+/// // In an Actix-web test, simulate the OAuth callback:
+/// let req = test::TestRequest::with_uri("/auth/callback?code=abc&state=xyz").to_http_request();
+/// let session = Session::default();
+/// let pool = web::Data::new(setup_test_pg_pool());
+/// let resp = callback(req, session, pool).await;
+/// assert_eq!(resp.status(), StatusCode::FOUND);
+/// ```
 pub async fn callback(req: HttpRequest, session: Session, pool: web::Data<PgPool>) -> HttpResponse {
     // Test mode: skip real OAuth for tests
     if std::env::var("TEST_MODE").unwrap_or_default() == "1" {

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -269,14 +269,30 @@ mod tests {
     #[actix_web::test]
     async fn login_redirect_should_redirect_to_github() {
         // Set env vars for test
-        std::env::set_var("GITHUB_CLIENT_ID", "testid");
-        std::env::set_var("GITHUB_REDIRECT_URL", "http://localhost/callback");
-        std::env::set_var("GITHUB_PERSONAL_ACCESS_TOKEN", "dummy_token");
-        std::env::set_var("DATABASE_URL", "postgres://dummy:dummy@localhost/dummy");
-        std::env::set_var("REDIS_URL", "redis://localhost:6379");
-        std::env::set_var("JWT_SECRET", "dummy_secret");
-        std::env::set_var("GITHUB_CLIENT_SECRET", "dummy_secret");
-        std::env::set_var("FRONTEND_URL", "http://localhost:3000");
+        unsafe {
+            std::env::set_var("GITHUB_CLIENT_ID", "testid");
+        }
+        unsafe {
+            std::env::set_var("GITHUB_REDIRECT_URL", "http://localhost/callback");
+        }
+        unsafe {
+            std::env::set_var("GITHUB_PERSONAL_ACCESS_TOKEN", "dummy_token");
+        }
+        unsafe {
+            std::env::set_var("DATABASE_URL", "postgres://dummy:dummy@localhost/dummy");
+        }
+        unsafe {
+            std::env::set_var("REDIS_URL", "redis://localhost:6379");
+        }
+        unsafe {
+            std::env::set_var("JWT_SECRET", "dummy_secret");
+        }
+        unsafe {
+            std::env::set_var("GITHUB_CLIENT_SECRET", "dummy_secret");
+        }
+        unsafe {
+            std::env::set_var("FRONTEND_URL", "http://localhost:3000");
+        }
         // Initialize app with login route
         let app = test::init_service(App::new().route("/auth/login", web::get().to(login))).await;
         // Send request
@@ -294,9 +310,15 @@ mod tests {
     #[ignore]
     async fn callback_returns_internal_server_error_for_invalid_code() {
         // Set env vars for test
-        std::env::set_var("GITHUB_CLIENT_ID", "testid");
-        std::env::set_var("GITHUB_CLIENT_SECRET", "testsecret");
-        std::env::set_var("GITHUB_REDIRECT_URL", "http://localhost/callback");
+        unsafe {
+            std::env::set_var("GITHUB_CLIENT_ID", "testid");
+        }
+        unsafe {
+            std::env::set_var("GITHUB_CLIENT_SECRET", "testsecret");
+        }
+        unsafe {
+            std::env::set_var("GITHUB_REDIRECT_URL", "http://localhost/callback");
+        }
         // Initialize app with callback route
         let app =
             test::init_service(App::new().route("/auth/callback", web::get().to(callback))).await;
@@ -321,11 +343,15 @@ mod callback_tests {
     #[actix_web::test]
     async fn callback_in_test_mode_sets_cookie() {
         dotenv::dotenv().ok();
-        std::env::set_var("JWT_SECRET", "secret");
-        std::env::set_var("TEST_MODE", "1");
+        unsafe {
+            std::env::set_var("JWT_SECRET", "secret");
+        }
+        unsafe {
+            std::env::set_var("TEST_MODE", "1");
+        }
         let db_url = std::env::var("TEST_DATABASE_URL").unwrap();
         let pool = PgPool::connect(&db_url).await.unwrap();
-        let session_key = Key::generate();
+        let _session_key = Key::generate();
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(pool))
@@ -350,12 +376,16 @@ mod pat_tests {
 
     #[actix_web::test]
     async fn pat_auth_in_test_mode_returns_jwt_and_user() {
-        std::env::set_var("JWT_SECRET", "secret");
-        std::env::set_var("TEST_MODE", "1");
+        unsafe {
+            std::env::set_var("JWT_SECRET", "secret");
+        }
+        unsafe {
+            std::env::set_var("TEST_MODE", "1");
+        }
         let app = test::init_service(App::new().route("/auth/pat", web::post().to(pat_auth))).await;
         let req = test::TestRequest::post()
             .uri("/auth/pat")
-            .set_json("dummy".into())
+            .set_json("dummy")
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);

--- a/backend/src/handlers/metrics.rs
+++ b/backend/src/handlers/metrics.rs
@@ -2,22 +2,19 @@
 
 use actix_web::{get, HttpResponse, Responder};
 use metrics_exporter_prometheus::PrometheusHandle;
+use once_cell::sync::OnceCell;
 
-static mut PROMETHEUS_HANDLE: Option<PrometheusHandle> = None;
+static PROMETHEUS_HANDLE: OnceCell<PrometheusHandle> = OnceCell::new();
 
 pub fn set_prometheus_handle(handle: PrometheusHandle) {
-    unsafe {
-        PROMETHEUS_HANDLE = Some(handle);
-    }
+    let _ = PROMETHEUS_HANDLE.set(handle);
 }
 
 #[get("/metrics")]
 pub async fn metrics() -> impl Responder {
-    let metrics = unsafe {
-        PROMETHEUS_HANDLE
-            .as_ref()
-            .map(|h| h.render())
-            .unwrap_or_default()
-    };
+    let metrics = PROMETHEUS_HANDLE
+        .get()
+        .map(|h| h.render())
+        .unwrap_or_default();
     HttpResponse::Ok().content_type("text/plain").body(metrics)
 }

--- a/backend/src/handlers/metrics.rs
+++ b/backend/src/handlers/metrics.rs
@@ -6,11 +6,26 @@ use once_cell::sync::OnceCell;
 
 static PROMETHEUS_HANDLE: OnceCell<PrometheusHandle> = OnceCell::new();
 
+/// Sets the global Prometheus metrics handle if it has not already been set.
+///
+/// Subsequent calls have no effect if the handle is already initialized.
 pub fn set_prometheus_handle(handle: PrometheusHandle) {
     let _ = PROMETHEUS_HANDLE.set(handle);
 }
 
 #[get("/metrics")]
+/// Handles HTTP GET requests to the `/metrics` endpoint, returning Prometheus metrics data.
+///
+/// If the Prometheus metrics handle has been initialized, this returns the current metrics as plain text.
+/// Otherwise, it returns an empty response body.
+///
+/// # Examples
+///
+/// ```
+/// // Register the handler in your Actix-web app:
+/// // app.route("/metrics", web::get().to(metrics));
+/// // Then, a GET request to /metrics returns Prometheus metrics.
+/// ```
 pub async fn metrics() -> impl Responder {
     let metrics = PROMETHEUS_HANDLE
         .get()

--- a/backend/src/handlers/metrics.rs
+++ b/backend/src/handlers/metrics.rs
@@ -1,6 +1,6 @@
 // TODO: Implement metrics handler module for repository analytics endpoints.
 
-use actix_web::{get, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, get};
 use metrics_exporter_prometheus::PrometheusHandle;
 use once_cell::sync::OnceCell;
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -9,7 +9,7 @@ pub mod users;
 
 pub use activities::*;
 pub use auth::*;
-pub use health::*;
+// pub use health::*;
 pub use metrics::*;
 pub use notifications::*;
 pub use organizations::*;

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -1,1 +1,4 @@
 // TODO: Implement notifications handler module for user notification endpoints.
+
+// This placeholder allows the notifications module to compile.
+pub fn notifications_placeholder() {}

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -1,4 +1,4 @@
 // TODO: Implement notifications handler module for user notification endpoints.
 
-// This placeholder allows the notifications module to compile.
+/// ```
 pub fn notifications_placeholder() {}

--- a/backend/src/handlers/organizations.rs
+++ b/backend/src/handlers/organizations.rs
@@ -5,7 +5,7 @@ use crate::db::{
     get_organization_by_id_with_cache, update_organization_description_with_cache,
 };
 use crate::utils::redis::RedisClient;
-use actix_web::{web, HttpResponse};
+use actix_web::{HttpResponse, web};
 use serde::Deserialize;
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/backend/src/handlers/repositories.rs
+++ b/backend/src/handlers/repositories.rs
@@ -5,7 +5,7 @@ use crate::db::{
 use crate::error::AppError;
 use crate::utils::config::Config;
 use crate::utils::redis::RedisClient;
-use actix_web::{web, HttpResponse};
+use actix_web::{HttpResponse, web};
 use octocrab::Octocrab;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -5,8 +5,8 @@ use crate::db::{
     update_user_avatar_with_cache,
 };
 use crate::utils::redis::RedisClient;
-use actix_web::{web, HttpResponse, Responder};
-use serde::{Deserialize, Serialize};
+use actix_web::{HttpResponse, Responder, web};
+use serde::Deserialize;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -31,6 +31,29 @@ fn _test_app_error_import() {
 }
 
 #[actix_web::main]
+/// Initializes and runs the Actix-web HTTP server with memory-efficient settings.
+///
+/// Loads configuration from environment variables, sets up a PostgreSQL connection pool,
+/// connects to Redis for session management and caching, preloads frequently accessed data into the cache,
+/// configures Prometheus metrics, applies CORS and rate limiting middleware, and starts the server
+/// with a limited number of workers and a restricted request payload size.
+///
+/// # Returns
+///
+/// Returns a `std::io::Result<()>` indicating the success or failure of the server startup.
+///
+/// # Panics
+///
+/// Panics if connecting to Redis or creating the Redis client fails, or if Prometheus metrics recorder installation fails.
+///
+/// # Examples
+///
+/// ```no_run
+/// #[tokio::main]
+/// async fn main() -> std::io::Result<()> {
+///     main().await
+/// }
+/// ```
 async fn main() -> std::io::Result<()> {
     // Load environment variables
     env_logger::init();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -23,7 +23,7 @@ use personal_github_dashboard::routes;
 use personal_github_dashboard::utils::cache_warm::warm_cache;
 use personal_github_dashboard::utils::config::Config;
 use personal_github_dashboard::utils::redis::RedisClient;
-use std::sync::Arc;
+// Removed unused import Arc and sync
 
 // Insert minimal AppError usage to test import
 fn _test_app_error_import() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,8 +1,8 @@
 use actix_cors::Cors;
 use actix_governor::{Governor, GovernorConfigBuilder};
-use actix_session::{storage::RedisSessionStore, SessionMiddleware};
+use actix_session::{SessionMiddleware, storage::RedisSessionStore};
 use actix_web::http::header;
-use actix_web::{web::PayloadConfig, App, HttpServer};
+use actix_web::{App, HttpServer, web::PayloadConfig};
 use cookie::Key;
 // removed unused import
 // use std::time::Duration;
@@ -131,7 +131,8 @@ async fn main() -> std::io::Result<()> {
             // Limit max payload size for requests (e.g. 256 KB)
             .app_data(PayloadConfig::new(262_144))
     })
-    .workers(2) // Limit to 2 workers for lower memory usage
+    // Use default worker count (num_cpus::get()) for optimal production performance
+    // .workers(num_cpus::get())
     .bind(bind_addr)?
     .run()
     .await

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod oauth_token;
 pub mod organization;
 pub mod repository;
 pub mod user;

--- a/backend/src/models/oauth_token.rs
+++ b/backend/src/models/oauth_token.rs
@@ -22,6 +22,18 @@ pub struct OAuthToken {
 }
 
 impl OAuthToken {
+    /// Encrypts a plaintext string using AES-256-GCM with a random nonce.
+    ///
+    /// The resulting byte vector contains the nonce followed by the ciphertext and authentication tag. Returns an error string if encryption fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let key = [0u8; 32];
+    /// let plaintext = "my_secret_token";
+    /// let encrypted = OAuthToken::encrypt_token(plaintext, &key).unwrap();
+    /// assert!(encrypted.len() > 12); // Nonce + ciphertext
+    /// ```
     pub fn encrypt_token(plain: &str, key: &[u8; 32]) -> Result<Vec<u8>, String> {
         let rng = SystemRandom::new();
         let mut nonce = [0u8; NONCE_LEN];
@@ -40,6 +52,20 @@ impl OAuthToken {
         result.extend_from_slice(&in_out);
         Ok(result)
     }
+    /// Decrypts an AES-256-GCM encrypted OAuth token and returns the plaintext string.
+    ///
+    /// Expects the input to contain the nonce followed by the ciphertext, as produced by `encrypt_token`.
+    /// Returns an error if the ciphertext is too short, the nonce or key is invalid, decryption fails, or the result is not valid UTF-8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let key = [0u8; 32];
+    /// let plaintext = "my_secret_token";
+    /// let ciphertext = OAuthToken::encrypt_token(plaintext, &key).unwrap();
+    /// let decrypted = OAuthToken::decrypt_token(&ciphertext, &key).unwrap();
+    /// assert_eq!(decrypted, plaintext);
+    /// ```
     pub fn decrypt_token(ciphertext: &[u8], key: &[u8; 32]) -> Result<String, String> {
         if ciphertext.len() < NONCE_LEN {
             return Err("ciphertext too short".into());

--- a/backend/src/models/oauth_token.rs
+++ b/backend/src/models/oauth_token.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
-use ring::aead;
-use ring::aead::{Aad, BoundKey, LessSafeKey, Nonce, UnboundKey, AES_256_GCM, NONCE_LEN};
+use ring::aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey};
 use ring::rand::{SecureRandom, SystemRandom};
+
+use thiserror::Error;
 
 #[derive(Debug, Serialize, Deserialize, FromRow, Clone)]
 pub struct OAuthToken {
@@ -21,6 +22,24 @@ pub struct OAuthToken {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    #[error("ciphertext too short")]
+    CiphertextTooShort,
+    #[error("invalid nonce")]
+    InvalidNonce,
+    #[error("key error: {0}")]
+    Key(String),
+    #[error("seal error: {0}")]
+    Seal(String),
+    #[error("open error: {0}")]
+    Open(String),
+    #[error("utf8 error: {0}")]
+    Utf8(String),
+    #[error("nonce generation error: {0}")]
+    NonceGen(String),
+}
+
 impl OAuthToken {
     /// Encrypts a plaintext string using AES-256-GCM with a random nonce.
     ///
@@ -34,20 +53,20 @@ impl OAuthToken {
     /// let encrypted = OAuthToken::encrypt_token(plaintext, &key).unwrap();
     /// assert!(encrypted.len() > 12); // Nonce + ciphertext
     /// ```
-    pub fn encrypt_token(plain: &str, key: &[u8; 32]) -> Result<Vec<u8>, String> {
+    pub fn encrypt_token(plain: &str, key: &[u8; 32]) -> Result<Vec<u8>, CryptoError> {
         let rng = SystemRandom::new();
-        let mut nonce = [0u8; NONCE_LEN];
+        let mut nonce = [0u8; 12];
         rng.fill(&mut nonce)
-            .map_err(|e| format!("nonce gen: {:?}", e))?;
+            .map_err(|e| CryptoError::NonceGen(format!("{:?}", e)))?;
         let nonce_bytes = nonce;
         let nonce = Nonce::assume_unique_for_key(nonce_bytes);
         let unbound_key =
-            UnboundKey::new(&AES_256_GCM, key).map_err(|e| format!("key: {:?}", e))?;
-        let mut sealing_key = LessSafeKey::new(unbound_key);
+            UnboundKey::new(&AES_256_GCM, key).map_err(|e| CryptoError::Key(format!("{:?}", e)))?;
+        let sealing_key = LessSafeKey::new(unbound_key);
         let mut in_out = plain.as_bytes().to_vec();
         sealing_key
             .seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
-            .map_err(|e| format!("seal: {:?}", e))?;
+            .map_err(|e| CryptoError::Seal(format!("{:?}", e)))?;
         let mut result = nonce_bytes.to_vec();
         result.extend_from_slice(&in_out);
         Ok(result)
@@ -66,19 +85,20 @@ impl OAuthToken {
     /// let decrypted = OAuthToken::decrypt_token(&ciphertext, &key).unwrap();
     /// assert_eq!(decrypted, plaintext);
     /// ```
-    pub fn decrypt_token(ciphertext: &[u8], key: &[u8; 32]) -> Result<String, String> {
-        if ciphertext.len() < NONCE_LEN {
-            return Err("ciphertext too short".into());
+    pub fn decrypt_token(ciphertext: &[u8], key: &[u8; 32]) -> Result<String, CryptoError> {
+        if ciphertext.len() < 12 {
+            return Err(CryptoError::CiphertextTooShort);
         }
-        let (nonce_bytes, ct) = ciphertext.split_at(NONCE_LEN);
-        let nonce = Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| "invalid nonce")?;
+        let (nonce_bytes, ct) = ciphertext.split_at(12);
+        let nonce =
+            Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| CryptoError::InvalidNonce)?;
         let unbound_key =
-            UnboundKey::new(&AES_256_GCM, key).map_err(|e| format!("key: {:?}", e))?;
-        let mut opening_key = LessSafeKey::new(unbound_key);
+            UnboundKey::new(&AES_256_GCM, key).map_err(|e| CryptoError::Key(format!("{:?}", e)))?;
+        let opening_key = LessSafeKey::new(unbound_key);
         let mut in_out = ct.to_vec();
         let plain = opening_key
             .open_in_place(nonce, Aad::empty(), &mut in_out)
-            .map_err(|e| format!("open: {:?}", e))?;
-        String::from_utf8(plain.to_vec()).map_err(|e| format!("utf8: {:?}", e))
+            .map_err(|e| CryptoError::Open(format!("{:?}", e)))?;
+        String::from_utf8(plain.to_vec()).map_err(|e| CryptoError::Utf8(format!("{:?}", e)))
     }
 }

--- a/backend/src/models/oauth_token.rs
+++ b/backend/src/models/oauth_token.rs
@@ -1,0 +1,58 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+use ring::aead;
+use ring::aead::{Aad, BoundKey, LessSafeKey, Nonce, UnboundKey, AES_256_GCM, NONCE_LEN};
+use ring::rand::{SecureRandom, SystemRandom};
+
+#[derive(Debug, Serialize, Deserialize, FromRow, Clone)]
+pub struct OAuthToken {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub provider: String,
+    pub access_token: Vec<u8>,          // encrypted
+    pub refresh_token: Option<Vec<u8>>, // encrypted
+    pub token_type: Option<String>,
+    pub scope: Option<String>,
+    pub expiry: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl OAuthToken {
+    pub fn encrypt_token(plain: &str, key: &[u8; 32]) -> Result<Vec<u8>, String> {
+        let rng = SystemRandom::new();
+        let mut nonce = [0u8; NONCE_LEN];
+        rng.fill(&mut nonce)
+            .map_err(|e| format!("nonce gen: {:?}", e))?;
+        let nonce_bytes = nonce;
+        let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+        let unbound_key =
+            UnboundKey::new(&AES_256_GCM, key).map_err(|e| format!("key: {:?}", e))?;
+        let mut sealing_key = LessSafeKey::new(unbound_key);
+        let mut in_out = plain.as_bytes().to_vec();
+        sealing_key
+            .seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
+            .map_err(|e| format!("seal: {:?}", e))?;
+        let mut result = nonce_bytes.to_vec();
+        result.extend_from_slice(&in_out);
+        Ok(result)
+    }
+    pub fn decrypt_token(ciphertext: &[u8], key: &[u8; 32]) -> Result<String, String> {
+        if ciphertext.len() < NONCE_LEN {
+            return Err("ciphertext too short".into());
+        }
+        let (nonce_bytes, ct) = ciphertext.split_at(NONCE_LEN);
+        let nonce = Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| "invalid nonce")?;
+        let unbound_key =
+            UnboundKey::new(&AES_256_GCM, key).map_err(|e| format!("key: {:?}", e))?;
+        let mut opening_key = LessSafeKey::new(unbound_key);
+        let mut in_out = ct.to_vec();
+        let plain = opening_key
+            .open_in_place(nonce, Aad::empty(), &mut in_out)
+            .map_err(|e| format!("open: {:?}", e))?;
+        String::from_utf8(plain.to_vec()).map_err(|e| format!("utf8: {:?}", e))
+    }
+}

--- a/backend/src/routes/init_routes.rs
+++ b/backend/src/routes/init_routes.rs
@@ -15,7 +15,7 @@ use crate::utils::config::Config;
 use crate::utils::jwt::validate_jwt;
 use crate::utils::redis::RedisClient;
 use actix_cors::Cors;
-use actix_web::{dev::ServiceRequest, web, Error, HttpResponse};
+use actix_web::{Error, HttpResponse, dev::ServiceRequest, web};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use actix_web_httpauth::middleware::HttpAuthentication;
 use sqlx::PgPool;

--- a/backend/src/utils/cache_warm.rs
+++ b/backend/src/utils/cache_warm.rs
@@ -8,7 +8,7 @@ use crate::models::{
 use crate::utils::redis::RedisClient;
 use log::{info, warn};
 use sqlx::PgPool;
-use uuid::Uuid;
+// use uuid::Uuid;
 
 /// Fetches up to N most recent entities of each type and warms the cache by calling their *_by_id_with_cache functions.
 pub async fn warm_cache(pool: &PgPool, redis: &RedisClient) {

--- a/backend/src/utils/config.rs
+++ b/backend/src/utils/config.rs
@@ -13,6 +13,16 @@ pub struct Config {
 }
 
 impl Config {
+    /// Loads configuration values from environment variables.
+    ///
+    /// Reads required configuration parameters from environment variables and constructs a `Config` instance. Panics if any required variable is missing, except for `FRONTEND_URL`, which defaults to `"http://localhost:3001"` if not set. The `GITHUB_REDIRECT_URL` must exactly match the callback URL registered in your GitHub OAuth app settings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let config = Config::from_env();
+    /// assert!(!config.database_url.is_empty());
+    /// ```
     pub fn from_env() -> Self {
         dotenv::dotenv().ok();
         Config {

--- a/backend/src/utils/config.rs
+++ b/backend/src/utils/config.rs
@@ -25,15 +25,10 @@ impl Config {
                 .expect("GITHUB_CLIENT_ID must be set"),
             github_client_secret: std::env::var("GITHUB_CLIENT_SECRET")
                 .expect("GITHUB_CLIENT_SECRET must be set"),
+            // Only use GITHUB_REDIRECT_URL for clarity and consistency
+            // This must match the callback URL registered in your GitHub OAuth app settings exactly (including port and path)
             github_redirect_url: std::env::var("GITHUB_REDIRECT_URL")
-                .or_else(|_| std::env::var("GITHUB_CALLBACK_URL"))
-                .unwrap_or_else(|_| {
-                    format!(
-                        "{}/auth/callback",
-                        std::env::var("FRONTEND_URL")
-                            .unwrap_or_else(|_| "http://localhost:3001".into())
-                    )
-                }),
+                .expect("GITHUB_REDIRECT_URL must be set"),
             frontend_url: std::env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:3001".to_string()),
         }

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -1,6 +1,6 @@
 use crate::error::AppError;
 use chrono::{Duration, Utc};
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/tests/activity_cache_integration.rs
+++ b/backend/tests/activity_cache_integration.rs
@@ -1,5 +1,5 @@
-use actix_web::{test, App};
-use jsonwebtoken::{encode, EncodingKey, Header};
+use actix_web::{App, test};
+use jsonwebtoken::{EncodingKey, Header, encode};
 use personal_github_dashboard::routes::init_routes;
 use personal_github_dashboard::utils::config::Config;
 use personal_github_dashboard::utils::redis::RedisClient;

--- a/backend/tests/activity_cache_integration.rs
+++ b/backend/tests/activity_cache_integration.rs
@@ -79,7 +79,7 @@ async fn test_activity_cache_flow() {
         .unwrap();
 
     // Start app
-    let mut app = test::init_service(
+    let app = test::init_service(
         App::new()
             .app_data(actix_web::web::Data::new(pool.clone()))
             .app_data(actix_web::web::Data::new(redis.clone()))
@@ -90,14 +90,14 @@ async fn test_activity_cache_flow() {
     // --- USER-ONLY ACTIVITY ---
     let req = test::TestRequest::post()
         .uri("/api/activities")
-        .set_json(&serde_json::json!({
+        .set_json(serde_json::json!({
             "user_id": test_user_id,
             "activity_type": test_activity_type,
             "details": "User-only activity"
         }))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("POST /api/activities (user-only) status: {}", status);
@@ -110,7 +110,7 @@ async fn test_activity_cache_flow() {
     // --- USER+REPO ACTIVITY ---
     let req = test::TestRequest::post()
         .uri("/api/activities")
-        .set_json(&serde_json::json!({
+        .set_json(serde_json::json!({
             "user_id": test_user_id,
             "repo_id": test_repo_id,
             "activity_type": test_activity_type,
@@ -118,7 +118,7 @@ async fn test_activity_cache_flow() {
         }))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("POST /api/activities (user+repo) status: {}", status);
@@ -131,7 +131,7 @@ async fn test_activity_cache_flow() {
     // --- USER+ORG ACTIVITY ---
     let req = test::TestRequest::post()
         .uri("/api/activities")
-        .set_json(&serde_json::json!({
+        .set_json(serde_json::json!({
             "user_id": test_user_id,
             "org_id": test_org_id,
             "activity_type": test_activity_type,
@@ -139,7 +139,7 @@ async fn test_activity_cache_flow() {
         }))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("POST /api/activities (user+org) status: {}", status);
@@ -160,7 +160,7 @@ async fn test_activity_cache_flow() {
             .uri(&format!("/api/activities/{}", activity_id))
             .insert_header(("Authorization", format!("Bearer {}", token)))
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         let status = resp.status();
         let body = test::read_body(resp).await;
         println!(
@@ -176,7 +176,7 @@ async fn test_activity_cache_flow() {
             .uri(&format!("/api/activities/{}", activity_id))
             .insert_header(("Authorization", format!("Bearer {}", token)))
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         let status = resp.status();
         let body = test::read_body(resp).await;
         println!(
@@ -192,7 +192,7 @@ async fn test_activity_cache_flow() {
             .uri(&format!("/api/activities/{}", activity_id))
             .insert_header(("Authorization", format!("Bearer {}", token)))
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         let status = resp.status();
         println!(
             "DELETE /api/activities/{} ({}) status: {}",
@@ -204,7 +204,7 @@ async fn test_activity_cache_flow() {
             .uri(&format!("/api/activities/{}", activity_id))
             .insert_header(("Authorization", format!("Bearer {}", token)))
             .to_request();
-        let resp = test::call_service(&mut app, req).await;
+        let resp = test::call_service(&app, req).await;
         let status = resp.status();
         println!(
             "GET (after delete) /api/activities/{} ({}) status: {}",

--- a/backend/tests/integration_caching.rs
+++ b/backend/tests/integration_caching.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 // Logger initialization for integration tests
 static INIT: Once = Once::new();
 
+/// ```
 fn init_logger() {
     INIT.call_once(|| {
         env_logger::Builder::from_default_env()
@@ -41,15 +42,40 @@ static TEST_REDIS: Lazy<Arc<RedisClient>> = Lazy::new(|| {
     Arc::new(redis)
 });
 
+/// Returns a clone of the shared PostgreSQL connection pool used for integration tests.
+///
+/// # Examples
+///
+/// ```
+/// let pool = get_test_pool();
+/// // Use `pool` to execute test queries.
+/// ```
 fn get_test_pool() -> Arc<PgPool> {
     TEST_POOL.clone()
 }
 
+/// Returns a clone of the shared Redis client used for integration tests.
+///
+/// # Examples
+///
+/// ```
+/// let redis = get_test_redis();
+/// // Use `redis` to interact with the test Redis instance.
+/// ```
 fn get_test_redis() -> Arc<RedisClient> {
     TEST_REDIS.clone()
 }
 
-// Helper: Truncate tables for a clean state before each test
+/// Removes all data from the `activities`, `repositories`, `organizations`, and `users` tables, resetting identity sequences and cascading deletions.
+///
+/// This ensures a clean database state before each test by truncating the relevant tables.
+///
+/// # Examples
+///
+/// ```
+/// let pool = get_test_pool();
+/// truncate_tables(&pool).await;
+/// ```
 async fn truncate_tables(pool: &PgPool) {
     sqlx::query!(
         "TRUNCATE TABLE activities, repositories, organizations, users RESTART IDENTITY CASCADE;"
@@ -97,6 +123,21 @@ async fn insert_repository(
         .execute(pool).await.expect("insert repo");
 }
 
+/// Inserts a test activity record into the database with the specified IDs and sample data.
+///
+/// The activity is created with a fixed type ("testtype"), current timestamp, and a sample JSON payload.
+/// Used to set up test data for integration tests involving activities.
+///
+/// # Examples
+///
+/// ```
+/// let pool = get_test_pool();
+/// let activity_id = Uuid::new_v4();
+/// let user_id = Uuid::new_v4();
+/// let repo_id = Some(Uuid::new_v4());
+/// insert_activity(&pool, activity_id, user_id, repo_id).await;
+/// ```
+async fn insert_activity(pool: &PgPool, activity_id: Uuid, user_id: Uuid, repo_id: Option<Uuid>) {
 async fn insert_activity(pool: &PgPool, activity_id: Uuid, user_id: Uuid, repo_id: Option<Uuid>) {
     sqlx::query!("INSERT INTO activities (id, user_id, repo_id, type, timestamp, data, created_at) VALUES ($1, $2, $3, $4, NOW(), $5, NOW())",
         activity_id, user_id, repo_id, "testtype", serde_json::json!({"k":"v"}))
@@ -104,6 +145,16 @@ async fn insert_activity(pool: &PgPool, activity_id: Uuid, user_id: Uuid, repo_i
 }
 
 #[actix_rt::test]
+/// Tests that user data is cached in Redis after the first API fetch and that subsequent requests retrieve the data from the cache.
+///
+/// This test inserts a user, fetches the user via the API to populate the cache, verifies the cache is set, and ensures a second fetch results in a cache hit.
+///
+/// # Examples
+///
+/// ```
+/// // Runs as part of the integration test suite; not intended for direct invocation.
+/// tokio_test::block_on(test_user_caching());
+/// ```
 async fn test_user_caching() {
     init_logger();
     dotenv().ok();
@@ -154,6 +205,17 @@ async fn test_user_caching() {
 }
 
 #[actix_rt::test]
+/// Tests that organization data is cached in Redis after the first API fetch and that subsequent fetches use the cache.
+///
+/// This test inserts an organization, fetches it via the API to populate the cache, verifies the cache is set,
+/// then fetches it again to ensure the cache is still present.
+///
+/// # Examples
+///
+/// ```
+/// // Runs as part of the integration test suite; not intended for direct invocation.
+/// // Verifies organization caching behavior.
+/// ```
 async fn test_organization_caching() {
     init_logger();
     dotenv().ok();
@@ -204,6 +266,17 @@ async fn test_organization_caching() {
 }
 
 #[actix_rt::test]
+/// Tests that repository data is cached in Redis after the first fetch and remains available on subsequent requests.
+///
+/// This integration test inserts a user, organization, and repository into the database, then fetches the repository via the API.
+/// It verifies that the repository data is cached in Redis after the first request and that the cache persists after a second request.
+///
+/// # Examples
+///
+/// ```
+/// // Runs as part of the integration test suite; not intended for direct invocation.
+/// tokio_test::block_on(test_repository_caching());
+/// ```
 async fn test_repository_caching() {
     init_logger();
     dotenv().ok();
@@ -258,6 +331,16 @@ async fn test_repository_caching() {
 }
 
 #[actix_rt::test]
+/// Tests that activity data is cached in Redis after the first API fetch and remains available on subsequent requests.
+///
+/// This test inserts a user, repository, and activity into the database, fetches the activity via the API, and verifies that the activity is cached in Redis. It then fetches the activity again to confirm the cache is still present.
+///
+/// # Examples
+///
+/// ```
+/// // Runs as part of the integration test suite; not intended for direct invocation.
+/// tokio_test::block_on(test_activity_caching());
+/// ```
 async fn test_activity_caching() {
     init_logger();
     dotenv().ok();
@@ -309,6 +392,21 @@ async fn test_activity_caching() {
 }
 
 #[actix_rt::test]
+/// Tests that requesting a non-existent user returns a 404 response and does not populate the Redis cache.
+///
+/// This test sends a GET request for a randomly generated user ID that does not exist in the database,
+/// verifies that the response status is 404 Not Found, and asserts that the corresponding Redis cache key
+/// is not set.
+///
+/// # Examples
+///
+/// ```
+/// // This test is intended to be run as part of the integration test suite.
+/// // It does not require any setup, as it generates a random user ID.
+/// tokio_test::block_on(async {
+///     test_user_cache_miss_and_invalid_id().await;
+/// });
+/// ```
 async fn test_user_cache_miss_and_invalid_id() {
     init_logger();
     dotenv().ok();
@@ -339,6 +437,16 @@ async fn test_user_cache_miss_and_invalid_id() {
 }
 
 #[actix_rt::test]
+/// Tests that the user cache entry expires after the configured TTL and is not repopulated after the user is deleted.
+///
+/// This test verifies that fetching a user populates the cache, the cache entry expires after the TTL, and subsequent requests for a deleted user do not repopulate the cache.
+///
+/// # Examples
+///
+/// ```
+/// // This is an integration test and is run as part of the test suite.
+/// // It does not return a value.
+/// ```
 async fn test_user_cache_ttl_and_invalidation() {
     init_logger();
     use std::time::Duration;

--- a/backend/tests/integration_caching.rs
+++ b/backend/tests/integration_caching.rs
@@ -140,6 +140,8 @@ async fn insert_activity(pool: &PgPool, activity_id: Uuid, user_id: Uuid, repo_i
 async fn test_user_caching() {
     init_logger();
     dotenv().ok();
+    // SAFETY: Setting environment variables in tests is required to isolate test state and avoid conflicts between tests running in parallel.
+    // This is safe here because tests are run serially (see #[serial] attribute) and only test configuration is affected.
     unsafe {
         std::env::set_var("USER_CACHE_TTL", "2");
     }
@@ -204,6 +206,8 @@ async fn test_user_caching() {
 async fn test_organization_caching() {
     init_logger();
     dotenv().ok();
+    // SAFETY: Setting environment variables in tests is required to isolate test state and avoid conflicts between tests running in parallel.
+    // This is safe here because tests are run serially (see #[serial] attribute) and only test configuration is affected.
     unsafe {
         std::env::set_var("USER_CACHE_TTL", "2");
     }
@@ -268,6 +272,8 @@ async fn test_organization_caching() {
 async fn test_repository_caching() {
     init_logger();
     dotenv().ok();
+    // SAFETY: Setting environment variables in tests is required to isolate test state and avoid conflicts between tests running in parallel.
+    // This is safe here because tests are run serially (see #[serial] attribute) and only test configuration is affected.
     unsafe {
         std::env::set_var("USER_CACHE_TTL", "2");
     }
@@ -335,6 +341,8 @@ async fn test_repository_caching() {
 async fn test_activity_caching() {
     init_logger();
     dotenv().ok();
+    // SAFETY: Setting environment variables in tests is required to isolate test state and avoid conflicts between tests running in parallel.
+    // This is safe here because tests are run serially (see #[serial] attribute) and only test configuration is affected.
     unsafe {
         std::env::set_var("USER_CACHE_TTL", "2");
     }
@@ -404,6 +412,8 @@ async fn test_activity_caching() {
 async fn test_user_cache_miss_and_invalid_id() {
     init_logger();
     dotenv().ok();
+    // SAFETY: Setting environment variables in tests is required to isolate test state and avoid conflicts between tests running in parallel.
+    // This is safe here because tests are run serially (see #[serial] attribute) and only test configuration is affected.
     unsafe {
         std::env::set_var("USER_CACHE_TTL", "2");
     }
@@ -449,6 +459,8 @@ async fn test_user_cache_ttl_and_invalidation() {
     use std::time::Duration;
     use tokio::time::sleep;
     dotenv().ok();
+    // SAFETY: Setting environment variables in tests is required to isolate test state and avoid conflicts between tests running in parallel.
+    // This is safe here because tests are run serially (see #[serial] attribute) and only test configuration is affected.
     unsafe {
         std::env::set_var("USER_CACHE_TTL", "2");
     }

--- a/backend/tests/integration_caching.rs
+++ b/backend/tests/integration_caching.rs
@@ -48,7 +48,7 @@ async fn get_test_redis() -> RedisClient {
     RedisClient::new(&redis_url).await.expect("Redis connect")
 }
 
-/// Removes all data from the `activities`, `repositories`, `organizations`, and `users` tables, resetting identity sequences and cascading deletions.
+/// Removes all data from the `activities`, `repositories`, `organizations`, `users`, and `oauth_tokens` tables, resetting identity sequences and cascading deletions.
 ///
 /// This ensures a clean database state before each test by truncating the relevant tables.
 ///
@@ -60,7 +60,7 @@ async fn get_test_redis() -> RedisClient {
 /// ```
 async fn truncate_tables(pool: &PgPool) {
     sqlx::query!(
-        "TRUNCATE TABLE activities, repositories, organizations, users RESTART IDENTITY CASCADE;"
+        "TRUNCATE TABLE activities, repositories, organizations, users, oauth_tokens RESTART IDENTITY CASCADE;"
     )
     .execute(pool)
     .await

--- a/backend/tests/integration_caching.rs
+++ b/backend/tests/integration_caching.rs
@@ -1,16 +1,10 @@
 use actix_web::{App, test};
 use dotenv::dotenv;
-use env_logger;
-use log;
-use once_cell::sync::Lazy;
 use personal_github_dashboard::routes::init_routes_test::init_routes_no_auth;
 use personal_github_dashboard::utils::redis::RedisClient;
-use serde_json;
 use serial_test::serial;
 use sqlx::PgPool;
-use std::sync::{Arc, Once};
-use std::time::Duration;
-use tokio::time::sleep;
+use std::sync::Once;
 use uuid::Uuid;
 
 // Logger initialization for integration tests
@@ -27,46 +21,31 @@ fn init_logger() {
 }
 
 // --- Shared test state ---
-static TEST_POOL: Lazy<Arc<PgPool>> = Lazy::new(|| {
-    let database_url = std::env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let pool = rt
-        .block_on(PgPool::connect(&database_url))
-        .expect("DB connect");
-    Arc::new(pool)
-});
 
-static TEST_REDIS: Lazy<Arc<RedisClient>> = Lazy::new(|| {
-    let redis_url = std::env::var("TEST_REDIS_URL").expect("TEST_REDIS_URL must be set");
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let redis = rt
-        .block_on(RedisClient::new(&redis_url))
-        .expect("Redis connect");
-    Arc::new(redis)
-});
-
-/// Returns a clone of the shared PostgreSQL connection pool used for integration tests.
+/// Returns a new PostgreSQL connection pool for integration tests.
 ///
 /// # Examples
 ///
 /// ```
-/// let pool = get_test_pool();
+/// let pool = get_test_pool().await;
 /// // Use `pool` to execute test queries.
 /// ```
-fn get_test_pool() -> Arc<PgPool> {
-    TEST_POOL.clone()
+async fn get_test_pool() -> PgPool {
+    let database_url = std::env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
+    PgPool::connect(&database_url).await.expect("DB connect")
 }
 
-/// Returns a clone of the shared Redis client used for integration tests.
+/// Returns a new Redis client for integration tests.
 ///
 /// # Examples
 ///
 /// ```
-/// let redis = get_test_redis();
+/// let redis = get_test_redis().await;
 /// // Use `redis` to interact with the test Redis instance.
 /// ```
-fn get_test_redis() -> Arc<RedisClient> {
-    TEST_REDIS.clone()
+async fn get_test_redis() -> RedisClient {
+    let redis_url = std::env::var("TEST_REDIS_URL").expect("TEST_REDIS_URL must be set");
+    RedisClient::new(&redis_url).await.expect("Redis connect")
 }
 
 /// Removes all data from the `activities`, `repositories`, `organizations`, and `users` tables, resetting identity sequences and cascading deletions.
@@ -76,7 +55,7 @@ fn get_test_redis() -> Arc<RedisClient> {
 /// # Examples
 ///
 /// ```
-/// let pool = get_test_pool();
+/// let pool = get_test_pool().await;
 /// truncate_tables(&pool).await;
 /// ```
 async fn truncate_tables(pool: &PgPool) {
@@ -134,7 +113,7 @@ async fn insert_repository(
 /// # Examples
 ///
 /// ```
-/// let pool = get_test_pool();
+/// let pool = get_test_pool().await;
 /// let activity_id = Uuid::new_v4();
 /// let user_id = Uuid::new_v4();
 /// let repo_id = Some(Uuid::new_v4());
@@ -161,9 +140,11 @@ async fn insert_activity(pool: &PgPool, activity_id: Uuid, user_id: Uuid, repo_i
 async fn test_user_caching() {
     init_logger();
     dotenv().ok();
-    std::env::set_var("USER_CACHE_TTL", "2");
-    let pool = get_test_pool();
-    let redis = get_test_redis();
+    unsafe {
+        std::env::set_var("USER_CACHE_TTL", "2");
+    }
+    let pool = get_test_pool().await;
+    let redis = get_test_redis().await;
     truncate_tables(&pool).await;
     let user_id = Uuid::new_v4();
     let username = format!("testuser-{}", user_id);
@@ -223,9 +204,11 @@ async fn test_user_caching() {
 async fn test_organization_caching() {
     init_logger();
     dotenv().ok();
-    std::env::set_var("USER_CACHE_TTL", "2");
-    let pool = get_test_pool();
-    let redis = get_test_redis();
+    unsafe {
+        std::env::set_var("USER_CACHE_TTL", "2");
+    }
+    let pool = get_test_pool().await;
+    let redis = get_test_redis().await;
     truncate_tables(&pool).await;
     let org_id = Uuid::new_v4();
     let name = format!("testorg-{}", org_id);
@@ -285,9 +268,11 @@ async fn test_organization_caching() {
 async fn test_repository_caching() {
     init_logger();
     dotenv().ok();
-    std::env::set_var("USER_CACHE_TTL", "2");
-    let pool = get_test_pool();
-    let redis = get_test_redis();
+    unsafe {
+        std::env::set_var("USER_CACHE_TTL", "2");
+    }
+    let pool = get_test_pool().await;
+    let redis = get_test_redis().await;
     truncate_tables(&pool).await;
     let org_id = Uuid::new_v4();
     let repo_id = Uuid::new_v4();
@@ -350,9 +335,11 @@ async fn test_repository_caching() {
 async fn test_activity_caching() {
     init_logger();
     dotenv().ok();
-    std::env::set_var("USER_CACHE_TTL", "2");
-    let pool = get_test_pool();
-    let redis = get_test_redis();
+    unsafe {
+        std::env::set_var("USER_CACHE_TTL", "2");
+    }
+    let pool = get_test_pool().await;
+    let redis = get_test_redis().await;
     truncate_tables(&pool).await;
     let user_id = Uuid::new_v4();
     let repo_id = Uuid::new_v4();
@@ -417,9 +404,11 @@ async fn test_activity_caching() {
 async fn test_user_cache_miss_and_invalid_id() {
     init_logger();
     dotenv().ok();
-    std::env::set_var("USER_CACHE_TTL", "2");
-    let pool = get_test_pool();
-    let redis = get_test_redis();
+    unsafe {
+        std::env::set_var("USER_CACHE_TTL", "2");
+    }
+    let pool = get_test_pool().await;
+    let redis = get_test_redis().await;
     truncate_tables(&pool).await;
     let random_id = Uuid::new_v4();
     let app = test::init_service(
@@ -460,9 +449,11 @@ async fn test_user_cache_ttl_and_invalidation() {
     use std::time::Duration;
     use tokio::time::sleep;
     dotenv().ok();
-    std::env::set_var("USER_CACHE_TTL", "2");
-    let pool = get_test_pool();
-    let redis = get_test_redis();
+    unsafe {
+        std::env::set_var("USER_CACHE_TTL", "2");
+    }
+    let pool = get_test_pool().await;
+    let redis = get_test_redis().await;
     truncate_tables(&pool).await;
     let user_id = Uuid::new_v4();
     let username = format!("testuser-{}", user_id);
@@ -493,7 +484,7 @@ async fn test_user_cache_ttl_and_invalidation() {
     assert!(cached.is_none(), "Cache should expire after TTL");
     // Invalidate cache by deleting user
     sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
-        .execute(&*pool)
+        .execute(&pool)
         .await
         .expect("delete user");
     // GET again, should return 404 and not repopulate cache

--- a/backend/tests/organization_cache_integration.rs
+++ b/backend/tests/organization_cache_integration.rs
@@ -1,5 +1,5 @@
-use actix_web::{test, App};
-use jsonwebtoken::{encode, EncodingKey, Header};
+use actix_web::{App, test};
+use jsonwebtoken::{EncodingKey, Header, encode};
 use personal_github_dashboard::routes::init_routes;
 use personal_github_dashboard::utils::config::Config;
 use personal_github_dashboard::utils::redis::RedisClient;

--- a/backend/tests/organization_cache_integration.rs
+++ b/backend/tests/organization_cache_integration.rs
@@ -52,7 +52,7 @@ async fn test_organization_cache_flow() {
         .unwrap();
 
     // Start app
-    let mut app = test::init_service(
+    let app = test::init_service(
         App::new()
             .app_data(actix_web::web::Data::new(pool.clone()))
             .app_data(actix_web::web::Data::new(redis.clone()))
@@ -63,13 +63,13 @@ async fn test_organization_cache_flow() {
     // Create organization (POST)
     let req = test::TestRequest::post()
         .uri("/api/organizations")
-        .set_json(&serde_json::json!({
+        .set_json(serde_json::json!({
             "name": test_org_name,
             "description": "Test org for cache integration"
         }))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("POST /api/organizations status: {}", status);
@@ -84,7 +84,7 @@ async fn test_organization_cache_flow() {
         .uri(&format!("/api/organizations/{}", org_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("GET /api/organizations/{} status: {}", org_id, status);
@@ -99,7 +99,7 @@ async fn test_organization_cache_flow() {
         .uri(&format!("/api/organizations/{}", org_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!(
@@ -118,10 +118,10 @@ async fn test_organization_cache_flow() {
     // Update organization description (PUT)
     let req = test::TestRequest::put()
         .uri(&format!("/api/organizations/{}/description", org_id))
-        .set_json(&serde_json::json!({"description": "Updated description"}))
+        .set_json(serde_json::json!({"description": "Updated description"}))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!(
@@ -142,7 +142,7 @@ async fn test_organization_cache_flow() {
         .uri(&format!("/api/organizations/{}", org_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     println!("DELETE /api/organizations/{} status: {}", org_id, status);
     assert_eq!(status, 204);
@@ -152,7 +152,7 @@ async fn test_organization_cache_flow() {
         .uri(&format!("/api/organizations/{}", org_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     println!(
         "GET (after delete) /api/organizations/{} status: {}",

--- a/backend/tests/repository_cache_integration.rs
+++ b/backend/tests/repository_cache_integration.rs
@@ -1,5 +1,5 @@
-use actix_web::{test, App};
-use jsonwebtoken::{encode, EncodingKey, Header};
+use actix_web::{App, test};
+use jsonwebtoken::{EncodingKey, Header, encode};
 use personal_github_dashboard::routes::init_routes;
 use personal_github_dashboard::utils::config::Config;
 use personal_github_dashboard::utils::redis::RedisClient;

--- a/backend/tests/repository_cache_integration.rs
+++ b/backend/tests/repository_cache_integration.rs
@@ -4,7 +4,7 @@ use personal_github_dashboard::routes::init_routes;
 use personal_github_dashboard::utils::config::Config;
 use personal_github_dashboard::utils::redis::RedisClient;
 use serde::{Deserialize, Serialize};
-use sqlx::{Executor, PgPool};
+use sqlx::PgPool;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize)]
@@ -42,7 +42,7 @@ async fn test_repository_cache_flow() {
     .unwrap();
 
     // Start app
-    let mut app = test::init_service(
+    let app = test::init_service(
         App::new()
             .app_data(actix_web::web::Data::new(pool.clone()))
             .app_data(actix_web::web::Data::new(redis.clone()))
@@ -62,7 +62,7 @@ async fn test_repository_cache_flow() {
         .unwrap();
     let req = test::TestRequest::post()
         .uri("/api/repositories")
-        .set_json(&serde_json::json!({
+        .set_json(serde_json::json!({
             "owner_id": test_owner_id,
             "name": test_repo_name,
             "description": "Test repo for cache integration",
@@ -70,7 +70,7 @@ async fn test_repository_cache_flow() {
         }))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("POST /api/repositories status: {}", status);
@@ -85,7 +85,7 @@ async fn test_repository_cache_flow() {
         .uri(&format!("/api/repositories/{}", repo_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!("GET /api/repositories/{} status: {}", repo_id, status);
@@ -100,7 +100,7 @@ async fn test_repository_cache_flow() {
         .uri(&format!("/api/repositories/{}", repo_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!(
@@ -119,10 +119,10 @@ async fn test_repository_cache_flow() {
     // Update repository description (PUT)
     let req = test::TestRequest::put()
         .uri(&format!("/api/repositories/{}/description", repo_id))
-        .set_json(&serde_json::json!({"description": "Updated description"}))
+        .set_json(serde_json::json!({"description": "Updated description"}))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     let body = test::read_body(resp).await;
     println!(
@@ -143,7 +143,7 @@ async fn test_repository_cache_flow() {
         .uri(&format!("/api/repositories/{}", repo_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     println!("DELETE /api/repositories/{} status: {}", repo_id, status);
     assert_eq!(status, 204);
@@ -153,7 +153,7 @@ async fn test_repository_cache_flow() {
         .uri(&format!("/api/repositories/{}", repo_id))
         .insert_header(("Authorization", format!("Bearer {}", token)))
         .to_request();
-    let resp = test::call_service(&mut app, req).await;
+    let resp = test::call_service(&app, req).await;
     let status = resp.status();
     println!(
         "GET (after delete) /api/repositories/{} status: {}",

--- a/backend/tests/user_cache.rs
+++ b/backend/tests/user_cache.rs
@@ -1,4 +1,4 @@
-use actix_web::{test, web, App};
+use actix_web::{App, test, web};
 use personal_github_dashboard::models::user::User;
 use personal_github_dashboard::utils::redis::RedisClient;
 use serde_json::json;

--- a/backend/tests/user_cache.rs
+++ b/backend/tests/user_cache.rs
@@ -1,7 +1,6 @@
 use actix_web::{App, test, web};
 use personal_github_dashboard::models::user::User;
 use personal_github_dashboard::utils::redis::RedisClient;
-use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/backend/tests/user_cache_integration.rs
+++ b/backend/tests/user_cache_integration.rs
@@ -1,7 +1,7 @@
 use actix_web::App;
 use chrono::{Duration, Utc};
 use dotenv;
-use jsonwebtoken::{encode, EncodingKey, Header};
+use jsonwebtoken::{EncodingKey, Header, encode};
 use personal_github_dashboard::utils::redis::RedisClient;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -35,7 +35,7 @@ REDIS_POOL_SIZE=5
 # GitHub Configuration
 GITHUB_CLIENT_ID=your_client_id
 GITHUB_CLIENT_SECRET=your_client_secret
-GITHUB_CALLBACK_URL=https://your-domain.com/api/auth/github/callback
+GITHUB_REDIRECT_URL=https://your-domain.com/api/auth/github/callback
 
 # Security
 JWT_SECRET=your_secure_jwt_secret

--- a/docs/github-oauth-setup.md
+++ b/docs/github-oauth-setup.md
@@ -18,7 +18,7 @@ Copy `.env.example` to `.env` and update the following variables with your crede
 
 - `GITHUB_CLIENT_ID`
 - `GITHUB_CLIENT_SECRET`
-- `GITHUB_CALLBACK_URL`
+- `GITHUB_REDIRECT_URL` # <-- Only this variable is required
 - `GITHUB_OAUTH_SCOPES`
 
 **Note:** Do not store any credentials in documentation or anywhere outside the .env files. Never commit secrets to a public repository.


### PR DESCRIPTION
## 3.1. Register GitHub OAuth Application
### Dependencies: None
### Description: Create and configure a GitHub OAuth application to obtain client ID and secret
### Details:
Register a new OAuth application in GitHub Developer Settings. Configure the application with appropriate callback URL (http://localhost:3000/auth/github/callback for development). Set required scopes (read:org, read:user, repo). Store the client ID and secret securely in environment variables. Document the OAuth application details for team reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced secure storage and encryption of OAuth tokens with a new database table.
  - Enhanced OAuth login and callback flow to support additional scopes and persist user/token data securely.
  - Added memory-efficient database connection pooling and server request payload size limits.
  - Added helper functions for database access and improved configuration handling.
  - Added placeholder notification handler function.

- **Bug Fixes**
  - Improved test reliability by centralizing database and Redis connections and ensuring test isolation via table truncation.

- **Documentation**
  - Updated GitHub OAuth environment variable names and setup instructions.
  - Enhanced backend code documentation for configuration, database, and metrics handling.
  - Added detailed doc comments to main server startup and test functions.

- **Chores**
  - Updated `.gitignore` and `.trivyignore` to exclude sensitive environment files.
  - Removed obsolete Codacy configuration.
  - Added new dependencies and refined build profiles for performance and security.
  - Removed public re-export of deprecated health module.

- **Tests**
  - Refactored integration tests for better resource management, maintainability, and sequential execution.
  - Simplified test service usage by removing mutable references and redundant environment loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->